### PR TITLE
Support entering boat during boat's initial rotation

### DIFF
--- a/src/main/java/ninjabrainbot/model/actions/boat/SetBoatAngleAction.java
+++ b/src/main/java/ninjabrainbot/model/actions/boat/SetBoatAngleAction.java
@@ -25,7 +25,7 @@ public class SetBoatAngleAction implements IAction {
 			return;
 		}
 
-		float candidate = Math.round(angle / 1.40625) * 1.40625f;
+		float candidate = (angle >= 0) ? Math.round(angle / 1.40625) * 1.40625f : Math.round(angle / 0.140625) * 0.140625f;
 		double rounded = Math.round(candidate * 100) / 100.0;
 
 		if (Math.abs(rounded - angle) > boatErrorLimit) {


### PR DESCRIPTION
When a boat is placed with negative yaw, it's yaw is set to a multiple of 1.40625, but it then rotates by 0.140625 for 10 ticks before settling on another multiple of 1.40625.

This change provides support for boat angle resetting during this rotation period.