### PR TITLE
support 1.13(.0) by not checking for minecraft: in initial clipboard filter

### DIFF
--- a/src/main/java/ninjabrainbot/model/datastate/endereye/F3CData.java
+++ b/src/main/java/ninjabrainbot/model/datastate/endereye/F3CData.java
@@ -15,7 +15,7 @@ public class F3CData {
 	}
 
 	public static F3CData tryParseF3CString(String string) {
-		if (!(string.startsWith("/execute in minecraft:"))) {
+		if (!(string.startsWith("/execute in "))) {
 			return null;
 		}
 		String[] substrings = string.split(" ");


### PR DESCRIPTION
for 1.13(.0) only, the dimension given back from f3 c doesn't have a namespace.

example output: `/execute in overworld run tp @s 256.38 73.18 37.39 148.05 -19.80`

i did a quick string check for "/execute in " in Keyboard.java in 1.21.3 and there were no other commands that started the same so this change shouldn't cause problems...?

1.13(.0) is the only 1.13 subversion where serious dedication isn't broken so it's important for aa