### PR TITLE
Add CORS headers to API

### DIFF
--- a/src/main/java/ninjabrainbot/io/api/ApiV1HttpHandler.java
+++ b/src/main/java/ninjabrainbot/io/api/ApiV1HttpHandler.java
@@ -89,6 +89,9 @@ public class ApiV1HttpHandler implements HttpHandler, IDisposable {
 
 	private void sendQueryResponse(HttpExchange exchange, IQuery query) {
 		try {
+			Headers responseHeaders = exchange.getResponseHeaders();
+			responseHeaders.add("Access-Control-Allow-Origin", "*");
+
 			OutputStream outputStream = exchange.getResponseBody();
 			exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
 			outputStream.write(query.get().getBytes());
@@ -105,6 +108,7 @@ public class ApiV1HttpHandler implements HttpHandler, IDisposable {
 			responseHeaders.add("Content-Type", "text/event-stream");
 			responseHeaders.add("Connection", "keep-alive");
 			responseHeaders.add("Transfer-Encoding", "chunked");
+			responseHeaders.add("Access-Control-Allow-Origin", "*");
 
 			OutputStream outputStream = exchange.getResponseBody();
 			exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);

--- a/src/main/java/ninjabrainbot/io/api/queries/StrongholdQuery.java
+++ b/src/main/java/ninjabrainbot/io/api/queries/StrongholdQuery.java
@@ -63,7 +63,7 @@ public class StrongholdQuery implements IQuery {
 			eyeThrowJson.put("angle", eyeThrow.horizontalAngle());
 			eyeThrowJson.put("angleWithoutCorrection", eyeThrow.horizontalAngleWithoutCorrection());
 			eyeThrowJson.put("correction", eyeThrow.correction());
-			eyeThrowJson.put("angleAdjustments", eyeThrow.correctionIncrements());
+			eyeThrowJson.put("correctionIncrements", eyeThrow.correctionIncrements());
 			eyeThrowJson.put("error", prediction != null ? prediction.getAngleError(eyeThrow) : 0);
 			eyeThrowJson.put("type", eyeThrow.getType());
 			eyeThrows.put(eyeThrowJson);

--- a/src/main/java/ninjabrainbot/io/api/queries/StrongholdQuery.java
+++ b/src/main/java/ninjabrainbot/io/api/queries/StrongholdQuery.java
@@ -63,6 +63,7 @@ public class StrongholdQuery implements IQuery {
 			eyeThrowJson.put("angle", eyeThrow.horizontalAngle());
 			eyeThrowJson.put("angleWithoutCorrection", eyeThrow.horizontalAngleWithoutCorrection());
 			eyeThrowJson.put("correction", eyeThrow.correction());
+			eyeThrowJson.put("angleAdjustments", eyeThrow.correctionIncrements());
 			eyeThrowJson.put("error", prediction != null ? prediction.getAngleError(eyeThrow) : 0);
 			eyeThrowJson.put("type", eyeThrow.getType());
 			eyeThrows.put(eyeThrowJson);

--- a/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
+++ b/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
@@ -59,7 +59,7 @@ public class ApiV1IntegrationTests {
 		Assertions.assertEquals(-318.63, eyeThrow1.getDouble("zInOverworld"));
 		Assertions.assertEquals(-45.529992377906794, eyeThrow1.getDouble("angle"));
 		Assertions.assertEquals(0, eyeThrow1.getDouble("correction"));
-		Assertions.assertEquals(0, eyeThrow1.getDouble("angleAdjustments"));
+		Assertions.assertEquals(0, eyeThrow1.getDouble("correctionIncrements"));
 		Assertions.assertEquals(-0.01593748756458524, eyeThrow1.getDouble("error"));
 		Assertions.assertEquals("NORMAL", eyeThrow1.getString("type"));
 
@@ -69,7 +69,7 @@ public class ApiV1IntegrationTests {
 		Assertions.assertEquals(-318.01, eyeThrow2.getDouble("zInOverworld"));
 		Assertions.assertEquals(-45.529992377906794, eyeThrow2.getDouble("angle"));
 		Assertions.assertEquals(0, eyeThrow2.getDouble("correction"));
-		Assertions.assertEquals(0, eyeThrow2.getDouble("angleAdjustments"));
+		Assertions.assertEquals(0, eyeThrow2.getDouble("correctionIncrements"));
 		Assertions.assertEquals(0.015504548661041895, eyeThrow2.getDouble("error"));
 		Assertions.assertEquals("NORMAL_WITH_ALT_STD", eyeThrow2.getString("type"));
 

--- a/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
+++ b/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
@@ -59,6 +59,7 @@ public class ApiV1IntegrationTests {
 		Assertions.assertEquals(-318.63, eyeThrow1.getDouble("zInOverworld"));
 		Assertions.assertEquals(-45.529992377906794, eyeThrow1.getDouble("angle"));
 		Assertions.assertEquals(0, eyeThrow1.getDouble("correction"));
+		Assertions.assertEquals(0, eyeThrow1.getDouble("angleAdjustments"));
 		Assertions.assertEquals(-0.01593748756458524, eyeThrow1.getDouble("error"));
 		Assertions.assertEquals("NORMAL", eyeThrow1.getString("type"));
 
@@ -68,6 +69,7 @@ public class ApiV1IntegrationTests {
 		Assertions.assertEquals(-318.01, eyeThrow2.getDouble("zInOverworld"));
 		Assertions.assertEquals(-45.529992377906794, eyeThrow2.getDouble("angle"));
 		Assertions.assertEquals(0, eyeThrow2.getDouble("correction"));
+		Assertions.assertEquals(0, eyeThrow2.getDouble("angleAdjustments"));
 		Assertions.assertEquals(0.015504548661041895, eyeThrow2.getDouble("error"));
 		Assertions.assertEquals("NORMAL_WITH_ALT_STD", eyeThrow2.getString("type"));
 


### PR DESCRIPTION
Implements #127 -- API requests (and subscriptions) now have CORS enabled for all routes so browsers/browser sources in OBS can interpret them.

I also exposed the `angleAdjustments` field for each eye, since it was already possible to calculate with some division (& it's a nice piece of information to have when building overlays).