### PR TITLE
allow raw keycodes on linux and mac when the normal keycode fails

### DIFF
--- a/src/main/java/ninjabrainbot/io/preferences/HotkeyPreference.java
+++ b/src/main/java/ninjabrainbot/io/preferences/HotkeyPreference.java
@@ -61,6 +61,8 @@ public class HotkeyPreference {
 	}
 
 	private static int getPlatformSpecificKeyCode(NativeKeyEvent nativeKeyEvent) {
-		return Platform.isLinux() || Platform.isMac() ? nativeKeyEvent.getKeyCode() | (nativeKeyEvent.getKeyLocation() << 16) : nativeKeyEvent.getRawCode();
+		int keyCode = nativeKeyEvent.getKeyCode();
+		boolean isValidKeyCode = keyCode != 0;
+		return isValidKeyCode && (Platform.isLinux() || Platform.isMac()) ? keyCode | (nativeKeyEvent.getKeyLocation() << 16) : nativeKeyEvent.getRawCode();
 	}
 }


### PR DESCRIPTION
When using Ninjabrain Bot 1.5.1 on Fedora 43, some keycodes are not correctly recognized as hotkeys:

My Corsair keyboard has additional G1-G6 keys which can be programmed/mapped using Corsair's iCUE software. On Linux I am using [ckb-next](https://github.com/ckb-next/ckb-next) to do this, as the official software is Windows-only. I mapped these G1-G6 keys to F19-F24 respectively.

But the problem is that Ninjabrain Bot doesn't register these keycodes as valid, so they don't work. This is likely related to [this issue](https://github.com/kwhat/jnativehook/issues/406) from [jnativehook](https://github.com/kwhat/jnativehook), as I encounter the same Xkb error in Ninjabrain Bot:
```
Feb 12, 2026 11:07:21 PM com.github.kwhat.jnativehook.GlobalScreen$NativeHookThread enable
SEVERE: load_input_helper [1827]: XkbGetKeyboard failed to locate a valid keyboard!
```

The library only registers the raw keycodes of the remapped G-keys, while the corresponding native keycode remains `0`.
In this PR, I added a simple `keyCode != 0` check to allow raw keycodes to be used if all other mappings fail.
As `0` indicates that no valid native keycode was found, falling back to the raw keycode allows these keys to be used without affecting the normal key handling. Therefore, this change is non-breaking.

1.5.1:
<img width="560" height="382" alt="12 02 2026 22_48_20" src="https://github.com/user-attachments/assets/11e1f30c-e9c5-43a9-8724-7c4d5e6574a3" />
Here you can see that the keys were registered as `Undefined` and were not recognized when pressed.

With this change:
<img width="560" height="382" alt="12 02 2026 22_46_47" src="https://github.com/user-attachments/assets/c90c02f5-3d17-41e9-8140-b7d2f947b9c7" />
After this fix, the correct names of the "virtual" keys were shown and the keys behaved as expected.