### PR TITLE
Add Input API

### DIFF
--- a/src/main/java/ninjabrainbot/gui/GUI.java
+++ b/src/main/java/ninjabrainbot/gui/GUI.java
@@ -167,7 +167,7 @@ public class GUI {
 		autoResetTimer = new AutoResetTimer(dataState, domainModel, actionExecutor, preferences);
 
 		obsOverlay = new OBSOverlay(ninjabrainBotFrame, preferences, dataState, domainModel, new NinjabrainBotOverlayImageWriter(), 1000);
-		ninjabrainBotHttpServer = new NinjabrainBotHttpServer(dataState, domainModel, informationMessageList, preferences);
+		ninjabrainBotHttpServer = new NinjabrainBotHttpServer(dataState, domainModel, informationMessageList, preferences, clipboardReader);
 
 		ninjabrainBotFrame.checkIfOffScreen();
 		ninjabrainBotFrame.setVisible(true);

--- a/src/main/java/ninjabrainbot/io/ClipboardReader.java
+++ b/src/main/java/ninjabrainbot/io/ClipboardReader.java
@@ -11,7 +11,7 @@ import ninjabrainbot.event.IObservable;
 import ninjabrainbot.event.ObservableField;
 import ninjabrainbot.io.preferences.NinjabrainBotPreferences;
 
-public class ClipboardReader implements IClipboardProvider, Runnable {
+public class ClipboardReader implements IClipboardProvider, IClipboardListener, Runnable {
 
 	private final NinjabrainBotPreferences preferences;
 
@@ -61,7 +61,7 @@ public class ClipboardReader implements IClipboardProvider, Runnable {
 			} catch (UnsupportedFlavorException | IllegalStateException | IOException ignored) {
 			}
 			if (clipboardString != null && !lastClipboardString.equals(clipboardString)) {
-				onClipboardUpdated(clipboardString);
+				setClipboard(clipboardString);
 				lastClipboardString = clipboardString;
 			}
 			// Sleep 0.1 seconds
@@ -73,7 +73,8 @@ public class ClipboardReader implements IClipboardProvider, Runnable {
 		}
 	}
 
-	private void onClipboardUpdated(String clipboard) {
+	@Override
+	public void setClipboard(String clipboard) {
 		clipboardString.set(clipboard);
 	}
 

--- a/src/main/java/ninjabrainbot/io/IClipboardListener.java
+++ b/src/main/java/ninjabrainbot/io/IClipboardListener.java
@@ -1,0 +1,5 @@
+package ninjabrainbot.io;
+
+public interface IClipboardListener {
+	void setClipboard(String clipboard);
+}

--- a/src/main/java/ninjabrainbot/io/api/ApiV1HttpHandler.java
+++ b/src/main/java/ninjabrainbot/io/api/ApiV1HttpHandler.java
@@ -1,6 +1,8 @@
 package ninjabrainbot.io.api;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
@@ -13,9 +15,14 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import ninjabrainbot.event.IDisposable;
+import ninjabrainbot.io.IClipboardListener;
+import ninjabrainbot.io.api.actions.IApiAction;
+import ninjabrainbot.io.api.actions.InputClipboardApiAction;
+import ninjabrainbot.io.api.actions.InputKeysApiAction;
 import ninjabrainbot.io.api.queries.AllAdvancementsQuery;
 import ninjabrainbot.io.api.queries.BlindQuery;
 import ninjabrainbot.io.api.queries.BoatQuery;
+import ninjabrainbot.io.api.queries.CalculatorStateQuery;
 import ninjabrainbot.io.api.queries.DivineQuery;
 import ninjabrainbot.io.api.queries.IQuery;
 import ninjabrainbot.io.api.queries.InformationMessagesQuery;
@@ -32,18 +39,25 @@ public class ApiV1HttpHandler implements HttpHandler, IDisposable {
 
 	private final EventSender eventSender;
 	private final HashMap<String, IQuery> queries;
+	private final HashMap<String, IApiAction> actions;
 
-	public ApiV1HttpHandler(IDataState dataState, IDomainModel domainModel, InformationMessageList informationMessageList, ExecutorService executorService) {
+	public ApiV1HttpHandler(IDataState dataState, IDomainModel domainModel, InformationMessageList informationMessageList, ExecutorService executorService, IClipboardListener clipboardListener) {
 		eventSender = new EventSender(domainModel, executorService);
+
 		queries = new HashMap<>();
 		queries.put("stronghold", new StrongholdQuery(dataState));
 		queries.put("all-advancements", new AllAdvancementsQuery(dataState));
 		queries.put("blind", new BlindQuery(dataState));
 		queries.put("divine", new DivineQuery(dataState));
 		queries.put("boat", new BoatQuery(dataState));
+		queries.put("calc-state", new CalculatorStateQuery(dataState));
 		queries.put("information-messages", new InformationMessagesQuery(informationMessageList));
 		queries.put("version", new VersionQuery());
 		queries.put("ping", new PingQuery());
+
+		actions = new HashMap<>();
+		actions.put("input-keys", new InputKeysApiAction());
+		actions.put("input-clipboard", new InputClipboardApiAction(clipboardListener));
 	}
 
 	@Override
@@ -55,21 +69,33 @@ public class ApiV1HttpHandler implements HttpHandler, IDisposable {
 			sendBadRequest(exchange);
 			return;
 		}
+		if ("get".equalsIgnoreCase(exchange.getRequestMethod())) {
+			IQuery query = queries.getOrDefault(subdirectories.get(0), null);
+			if (query == null) {
+				sendBadRequest(exchange);
+				return;
+			}
 
-		IQuery query = queries.getOrDefault(subdirectories.get(0), null);
-		if (query == null) {
-			sendBadRequest(exchange);
-			return;
-		}
+			if (subdirectories.size() == 1) {
+				sendQueryResponse(exchange, query);
+				return;
+			}
 
-		if (subdirectories.size() == 1) {
-			sendQueryResponse(exchange, query);
-			return;
-		}
+			if (query.supportsSubscriptions() && subdirectories.size() == 2 && subdirectories.get(1).contentEquals("events")) {
+				subscribeToQuery(exchange, query);
+				return;
+			}
+		} else if ("post".equalsIgnoreCase(exchange.getRequestMethod())) {
+			IApiAction action = actions.getOrDefault(subdirectories.get(0), null);
+			if (action == null) {
+				sendBadRequest(exchange);
+				return;
+			}
 
-		if (query.supportsSubscriptions() && subdirectories.size() == 2 && subdirectories.get(1).contentEquals("events")) {
-			subscribeToQuery(exchange, query);
-			return;
+			if (subdirectories.size() == 1) {
+				sendActionResponse(exchange, action);
+				return;
+			}
 		}
 
 		sendBadRequest(exchange);
@@ -99,6 +125,30 @@ public class ApiV1HttpHandler implements HttpHandler, IDisposable {
 			outputStream.close();
 		} catch (IOException e) {
 			Logger.log("HTTP server failed to send query response: " + e);
+		}
+	}
+
+	private void sendActionResponse(HttpExchange exchange, IApiAction action) {
+		try {
+			try {
+				String body = new BufferedReader(new InputStreamReader(exchange.getRequestBody())).lines()
+						.collect(Collectors.joining(System.lineSeparator()));
+				String response = action.post(body);
+
+				Headers responseHeaders = exchange.getResponseHeaders();
+				responseHeaders.add("Access-Control-Allow-Origin", "*");
+
+				OutputStream outputStream = exchange.getResponseBody();
+				exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
+				outputStream.write(response.getBytes());
+				outputStream.flush();
+				outputStream.close();
+			} catch (RuntimeException e) {
+				Logger.log("Invalid request handling: " + e);
+				sendBadRequest(exchange);
+			}
+		} catch (IOException e) {
+			Logger.log("HTTP server failed to send action response: " + e);
 		}
 	}
 

--- a/src/main/java/ninjabrainbot/io/api/NinjabrainBotHttpServer.java
+++ b/src/main/java/ninjabrainbot/io/api/NinjabrainBotHttpServer.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import com.sun.net.httpserver.HttpServer;
 import ninjabrainbot.event.DisposeHandler;
 import ninjabrainbot.event.IDisposable;
+import ninjabrainbot.io.IClipboardListener;
 import ninjabrainbot.io.preferences.NinjabrainBotPreferences;
 import ninjabrainbot.model.datastate.IDataState;
 import ninjabrainbot.model.domainmodel.IDomainModel;
@@ -20,6 +21,7 @@ public class NinjabrainBotHttpServer implements IDisposable {
 	private final IDomainModel domainModel;
 	private final InformationMessageList informationMessageList;
 	private final NinjabrainBotPreferences preferences;
+	private final IClipboardListener clipboardListener;
 	private final DisposeHandler disposeHandler = new DisposeHandler();
 
 	private HttpServer httpServer;
@@ -27,11 +29,12 @@ public class NinjabrainBotHttpServer implements IDisposable {
 	private ExecutorService executorService;
 	private Exception error;
 
-	public NinjabrainBotHttpServer(IDataState dataState, IDomainModel domainModel, InformationMessageList informationMessageList, NinjabrainBotPreferences preferences) {
+	public NinjabrainBotHttpServer(IDataState dataState, IDomainModel domainModel, InformationMessageList informationMessageList, NinjabrainBotPreferences preferences, IClipboardListener clipboardListener) {
 		this.dataState = dataState;
 		this.domainModel = domainModel;
 		this.informationMessageList = informationMessageList;
 		this.preferences = preferences;
+		this.clipboardListener = clipboardListener;
 		updateHttpServerStatus();
 
 		disposeHandler.add(preferences.enableHttpServer.whenModified().subscribe(this::updateHttpServerStatus));
@@ -58,7 +61,7 @@ public class NinjabrainBotHttpServer implements IDisposable {
 		}
 		if (executorService == null)
 			executorService = Executors.newFixedThreadPool(1);
-		apiV1HttpHandler = new ApiV1HttpHandler(dataState, domainModel, informationMessageList, executorService);
+		apiV1HttpHandler = new ApiV1HttpHandler(dataState, domainModel, informationMessageList, executorService, clipboardListener);
 		httpServer.createContext("/api/v1", apiV1HttpHandler);
 		httpServer.setExecutor(executorService);
 		httpServer.start();

--- a/src/main/java/ninjabrainbot/io/api/actions/IApiAction.java
+++ b/src/main/java/ninjabrainbot/io/api/actions/IApiAction.java
@@ -1,0 +1,7 @@
+package ninjabrainbot.io.api.actions;
+
+public interface IApiAction {
+
+	String post(String body);
+
+}

--- a/src/main/java/ninjabrainbot/io/api/actions/InputClipboardApiAction.java
+++ b/src/main/java/ninjabrainbot/io/api/actions/InputClipboardApiAction.java
@@ -1,0 +1,18 @@
+package ninjabrainbot.io.api.actions;
+
+import ninjabrainbot.io.IClipboardListener;
+
+public class InputClipboardApiAction implements IApiAction {
+
+	private final IClipboardListener clipboardListener;
+
+	public InputClipboardApiAction(IClipboardListener clipboardListener) {
+		this.clipboardListener = clipboardListener;
+	}
+
+	@Override
+	public String post(String body) {
+		clipboardListener.setClipboard(body);
+		return "copied";
+	}
+}

--- a/src/main/java/ninjabrainbot/io/api/actions/InputKeysApiAction.java
+++ b/src/main/java/ninjabrainbot/io/api/actions/InputKeysApiAction.java
@@ -1,0 +1,45 @@
+package ninjabrainbot.io.api.actions;
+
+
+import ninjabrainbot.io.preferences.HotkeyPreference;
+import org.json.JSONArray;
+
+import javax.swing.SwingUtilities;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class InputKeysApiAction implements IApiAction {
+	@Override
+	public String post(String body) throws RuntimeException {
+		Map<String, HotkeyPreference> hotkeyMap = HotkeyPreference.hotkeys.stream()
+				.collect(Collectors.toMap(HotkeyPreference::getKey, Function.identity(), (h1, h2) -> h1));
+
+		JSONArray hotkeys = new JSONArray(body);
+		for (Object input : hotkeys) {
+			String hotkeyId;
+			int count;
+			if (input instanceof JSONArray) {
+				JSONArray array = (JSONArray) input;
+				hotkeyId = array.getString(0);
+				count = array.getInt(1);
+			} else if (input instanceof String) {
+				hotkeyId = (String) input;
+				count = 1;
+			} else {
+				throw new RuntimeException("Invalid Format: " + input);
+			}
+			// prevent accidental over pressing
+			count = Math.min(count, 50);
+
+			HotkeyPreference hotkey = hotkeyMap.get(hotkeyId);
+			if (hotkey != null)
+				for (int i = 0; i < count; i++) {
+					SwingUtilities.invokeLater(hotkey::execute);
+				}
+			else
+				throw new IllegalArgumentException("Invalid Hotkey: " + input);
+		}
+		return "success";
+	}
+}

--- a/src/main/java/ninjabrainbot/io/api/queries/CalculatorStateQuery.java
+++ b/src/main/java/ninjabrainbot/io/api/queries/CalculatorStateQuery.java
@@ -1,0 +1,32 @@
+package ninjabrainbot.io.api.queries;
+
+import ninjabrainbot.model.datastate.IDataState;
+import ninjabrainbot.model.datastate.endereye.IEnderEyeThrow;
+import ninjabrainbot.model.domainmodel.IListComponent;
+import org.json.JSONObject;
+
+public class CalculatorStateQuery implements IQuery {
+	private final IDataState dataState;
+
+	public CalculatorStateQuery(IDataState dataState) {
+		this.dataState = dataState;
+	}
+
+	@Override
+	public String get() {
+		IListComponent<IEnderEyeThrow> throwList = dataState.getThrowList();
+		int angleCount = throwList.size();
+		JSONObject root = new JSONObject();
+		root.put("boatState", dataState.boatDataState().boatState().get());
+		root.put("adjustment", angleCount > 0 ? throwList.getLast().correctionIncrements() : 0);
+		root.put("angleCount", angleCount);
+		root.put("isAllAdvancementsModeEnabled", dataState.allAdvancementsDataState().allAdvancementsModeEnabled().get());
+		root.put("locked", dataState.locked().get());
+		return root.toString();
+	}
+
+	@Override
+	public boolean supportsSubscriptions() {
+		return true;
+	}
+}

--- a/src/main/java/ninjabrainbot/io/api/queries/IQuery.java
+++ b/src/main/java/ninjabrainbot/io/api/queries/IQuery.java
@@ -1,7 +1,5 @@
 package ninjabrainbot.io.api.queries;
 
-import ninjabrainbot.model.datastate.IDataState;
-
 public interface IQuery {
 
 	String get();

--- a/src/main/java/ninjabrainbot/io/preferences/HotkeyPreference.java
+++ b/src/main/java/ninjabrainbot/io/preferences/HotkeyPreference.java
@@ -15,15 +15,21 @@ public class HotkeyPreference {
 
 	final IntPreference modifier;
 	final IntPreference code;
+	final String key;
 
 	private final ObservableProperty<HotkeyPreference> whenTriggered;
 
 	public HotkeyPreference(String key, IPreferenceSource pref) {
 		this.pref = pref;
+		this.key = key;
 		modifier = new IntPreference(key + "_modifier", -1, pref);
 		code = new IntPreference(key + "_code", -1, pref);
 		hotkeys.add(this);
 		whenTriggered = new ObservableProperty<>();
+	}
+
+	public String getKey() {
+		return key;
 	}
 
 	public int getCode() {

--- a/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
+++ b/src/test/java/ninjabrainbot/integrationtests/ApiV1IntegrationTests.java
@@ -1,13 +1,17 @@
 package ninjabrainbot.integrationtests;
 
+import javax.swing.SwingUtilities;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +24,7 @@ import ninjabrainbot.Main;
 import ninjabrainbot.io.api.ApiV1HttpHandler;
 import ninjabrainbot.io.mcinstance.MinecraftInstance;
 import ninjabrainbot.io.mcinstance.MinecraftWorldFile;
+import ninjabrainbot.io.preferences.HotkeyPreference;
 import ninjabrainbot.io.preferences.enums.McVersion;
 import ninjabrainbot.model.datastate.common.ResultType;
 import org.json.JSONArray;
@@ -36,7 +41,7 @@ public class ApiV1IntegrationTests {
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withProSettings();
 		builder.preferences.sigmaAlt.set(0.005f);
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		builder.setClipboard("/execute in minecraft:overworld run tp @s 1213.26 71.00 -318.63 -45.53 -31.39");
 		builder.setClipboard("/execute in minecraft:overworld run tp @s 1212.65 69.00 -318.01 -45.53 -31.52");
@@ -98,7 +103,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/all-advancements");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withAllAdvancementsSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService,  builder.clipboardReader);
 
 		builder.setClipboard("/execute in minecraft:overworld run tp @s 1477.68 70.00 -211.29 -103.76 -31.31");
 		builder.enterNewWorld();
@@ -159,7 +164,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/blind");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		builder.setClipboard("/execute in minecraft:the_nether run tp @s -217.82 85.00 6.88 -133.68 81.14");
 
@@ -194,7 +199,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/divine");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		builder.setClipboard("/setblock 5 73 0 minecraft:bone_block[axis=y]");
 
@@ -223,7 +228,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/boat");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		builder.triggerHotkey(builder.preferences.hotkeyBoat);
 		builder.setClipboard("/execute in minecraft:overworld run tp @s 1274.04 92.55 1064.56 -77.34375 32.82");
@@ -252,7 +257,7 @@ public class ApiV1IntegrationTests {
 				.withProSettings()
 				.withAllInformationMessagesSettings()
 				.withMcVersionSetting(McVersion.PRE_119);
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		builder.setActiveMinecraftWorld(new MinecraftWorldFile(new MinecraftInstance("directory"), "worldName"), McVersion.POST_119);
 		builder.setClipboard("/execute in minecraft:overworld run tp @s 2408 65.00 8 0 -31.87");
@@ -304,7 +309,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/version");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		// Act
 		apiV1HttpHandler.handle(exchange);
@@ -326,7 +331,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/ping");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		// Act
 		apiV1HttpHandler.handle(exchange);
@@ -340,12 +345,106 @@ public class ApiV1IntegrationTests {
 	}
 
 	@Test
+	void calcStateNoAngles() throws IOException {
+		// Arrange
+		TestHttpExchange exchange = new TestHttpExchange("/api/v1/calc-state");
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
+
+		// Act
+		apiV1HttpHandler.handle(exchange);
+
+		// Assert
+		Assertions.assertEquals(HttpURLConnection.HTTP_OK, exchange.getResponseCode());
+		String expectedResult =
+				("{" +
+						"\"boatState\":\"NONE\"," +
+						"\"adjustment\":0," +
+						"\"locked\":false," +
+						"\"angleCount\":0," +
+						"\"isAllAdvancementsModeEnabled\":false" +
+						"}").replaceAll("\\s+", "");
+		Assertions.assertEquals(expectedResult, exchange.getResponseBodyAsString());
+	}
+
+	@Test
+	void calcState() throws IOException {
+		// Arrange
+		TestHttpExchange exchange = new TestHttpExchange("/api/v1/calc-state");
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
+
+		// Act
+		builder.setClipboard("/execute in minecraft:overworld run tp @s 128.68 67.00 -72.11 -57.90 -48.05");
+		builder.triggerHotkey(builder.preferences.hotkeyIncrement);
+		builder.triggerHotkey(builder.preferences.hotkeyIncrement);
+		builder.triggerHotkey(builder.preferences.hotkeyBoat);
+		builder.triggerHotkey(builder.preferences.hotkeyLock);
+		apiV1HttpHandler.handle(exchange);
+
+		// Assert
+		Assertions.assertEquals(HttpURLConnection.HTTP_OK, exchange.getResponseCode());
+		String expectedResult =
+				("{" +
+						"\"boatState\":\"MEASURING\"," +
+						"\"adjustment\":2," +
+						"\"locked\":true," +
+						"\"angleCount\":1," +
+						"\"isAllAdvancementsModeEnabled\":false" +
+						"}").replaceAll("\\s+", "");
+		Assertions.assertEquals(expectedResult, exchange.getResponseBodyAsString());
+	}
+
+	@Test
+	void inputClipboard() throws IOException {
+		// Arrange
+		TestHttpExchange exchange = new TestHttpExchange("/api/v1/input-clipboard");
+		exchange.setRequestBody("/execute in minecraft:overworld run tp @s 128.68 67.00 -72.11 -57.90 -48.05");
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		IntegrationTestBuilder builder = new IntegrationTestBuilder().withClipboardReader();
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
+		// Act
+		apiV1HttpHandler.handle(exchange);
+
+		// Assert
+		Assertions.assertEquals(HttpURLConnection.HTTP_OK, exchange.getResponseCode());
+
+		String expectedResult = "copied";
+		Assertions.assertEquals(expectedResult, exchange.getResponseBodyAsString());
+		Assertions.assertEquals(1, builder.dataState.getThrowList().size());
+	}
+
+	@Test
+	void inputKeys() throws IOException, InterruptedException, InvocationTargetException {
+		// Arrange
+		TestHttpExchange exchange = new TestHttpExchange("/api/v1/input-keys");
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		HotkeyPreference.hotkeys.clear();
+		IntegrationTestBuilder builder = new IntegrationTestBuilder().withHotkeyInputHandler();
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
+		// Act
+		builder.setClipboard("/execute in minecraft:overworld run tp @s 128.68 67.00 -72.11 -57.90 -48.05");
+		exchange.setRequestBody("[[\"hotkey_increment\", 20], \"hotkey_reset\", \"hotkey_undo\"]");
+		apiV1HttpHandler.handle(exchange);
+		SwingUtilities.invokeAndWait(() -> {});
+		// Assert
+		Assertions.assertEquals(HttpURLConnection.HTTP_OK, exchange.getResponseCode());
+
+		String expectedResult = "success";
+		Assertions.assertEquals(expectedResult, exchange.getResponseBodyAsString());
+		Assertions.assertEquals(1, builder.dataState.getThrowList().size());
+		Assertions.assertEquals(20, builder.dataState.getThrowList().getLast().correctionIncrements());
+	}
+
+	@Test
 	void subscribe_pushesNewDataWhenModified() throws IOException, InterruptedException {
 		// Arrange
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/boat/events");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		// Act 1
 		apiV1HttpHandler.handle(exchange);
@@ -372,7 +471,7 @@ public class ApiV1IntegrationTests {
 		TestHttpExchange exchange = new TestHttpExchange("/api/v1/boat/events");
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		IntegrationTestBuilder builder = new IntegrationTestBuilder().withBoatSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		// Act 1
 		apiV1HttpHandler.handle(exchange);
@@ -403,7 +502,7 @@ public class ApiV1IntegrationTests {
 		IntegrationTestBuilder builder = new IntegrationTestBuilder()
 				.withProSettings()
 				.withAllInformationMessagesSettings();
-		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService);
+		ApiV1HttpHandler apiV1HttpHandler = new ApiV1HttpHandler(builder.dataState, builder.domainModel, builder.createInformationMessageList(), executorService, builder.clipboardReader);
 
 		// Act 1
 		apiV1HttpHandler.handle(exchange);
@@ -452,6 +551,7 @@ public class ApiV1IntegrationTests {
 
 		private final String endpoint;
 		public OutputStream outputStream = new ByteArrayOutputStream();
+		public InputStream inputStream = null;
 		private int responseCode = 0;
 
 		public TestHttpExchange(String endpoint) {
@@ -483,7 +583,7 @@ public class ApiV1IntegrationTests {
 
 		@Override
 		public String getRequestMethod() {
-			return null;
+			return getRequestBody() == null ? "get" : "post";
 		}
 
 		@Override
@@ -496,9 +596,13 @@ public class ApiV1IntegrationTests {
 
 		}
 
+		public void setRequestBody(String body) {
+			inputStream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+		}
+
 		@Override
 		public InputStream getRequestBody() {
-			return null;
+			return inputStream;
 		}
 
 		@Override

--- a/src/test/java/ninjabrainbot/integrationtests/IntegrationTestBuilder.java
+++ b/src/test/java/ninjabrainbot/integrationtests/IntegrationTestBuilder.java
@@ -61,9 +61,9 @@ public class IntegrationTestBuilder {
 	public final IEnvironmentState environmentState;
 	public final IDataState dataState;
 
+	public MockedClipboardReader clipboardReader;
 	private CoordinateInputSource coordinateInputSource;
 	private FakeCoordinateInputSource fakeCoordinateInputSource;
-	private MockedClipboardReader clipboardReader;
 	private MockedInstanceProvider activeInstanceProvider;
 
 	private PlayerPositionInputHandler playerPositionInputHandler;
@@ -142,11 +142,16 @@ public class IntegrationTestBuilder {
 		return this;
 	}
 
-	public void setClipboard(String clipboardString) {
+	public IntegrationTestBuilder withClipboardReader() {
 		if (clipboardReader == null) clipboardReader = new MockedClipboardReader();
 		if (coordinateInputSource == null) coordinateInputSource = new CoordinateInputSource(clipboardReader);
 		if (playerPositionInputHandler == null) playerPositionInputHandler = createPlayerPositionInputHandler();
 		if (f3iLocationInputHandler == null) f3iLocationInputHandler = new F3ILocationInputHandler(coordinateInputSource, dataState, actionExecutor, preferences);
+		return this;
+	}
+
+	public void setClipboard(String clipboardString) {
+		withClipboardReader();
 		clipboardReader.setClipboard(clipboardString);
 	}
 
@@ -169,8 +174,13 @@ public class IntegrationTestBuilder {
 	}
 
 	public void triggerHotkey(HotkeyPreference hotkeyPreference) {
-		if (hotkeyInputHandler == null) hotkeyInputHandler = new HotkeyInputHandler(preferences, domainModel, dataState, actionExecutor);
+		withHotkeyInputHandler();
 		hotkeyPreference.execute();
+	}
+
+	public IntegrationTestBuilder withHotkeyInputHandler() {
+		if (hotkeyInputHandler == null) hotkeyInputHandler = new HotkeyInputHandler(preferences, domainModel, dataState, actionExecutor);
+		return this;
 	}
 
 	public void setActiveMinecraftWorld(IMinecraftWorldFile minecraftWorld) {

--- a/src/test/java/ninjabrainbot/util/MockedClipboardReader.java
+++ b/src/test/java/ninjabrainbot/util/MockedClipboardReader.java
@@ -2,12 +2,14 @@ package ninjabrainbot.util;
 
 import ninjabrainbot.event.IObservable;
 import ninjabrainbot.event.ObservableField;
+import ninjabrainbot.io.IClipboardListener;
 import ninjabrainbot.io.IClipboardProvider;
 
-public class MockedClipboardReader implements IClipboardProvider {
+public class MockedClipboardReader implements IClipboardProvider, IClipboardListener {
 
 	private final ObservableField<String> clipboard = new ObservableField<>("");
 
+	@Override
 	public void setClipboard(String string) {
 		clipboard.set(string);
 	}


### PR DESCRIPTION
Added 3 new routes:

## GET /api/v1/calc-state

returns data about the current input/state of the calculator, but without any results.

This is so tools using this route do not accidentally classify themselves as calculators, the values provided by this route are intended to be safe to use in the vast majority of contexts.

## POST /api/v1/input-keys

provide a list of hotkeys, and the calculator will press them, optionally provide how many times to hit a specific hotkey. (capped at 50 to prevent bugs in tools from crashing the calculator)

This is provided both to allow opting out of giving access to global hotkey reading, (where it may be hard to provide for users who are not administrators of their machines) and to allow for more novel ways of inputting this data. (for example, an external program allowing you to type the offset, and then pressing the increment key that many times).

## POST /api/v1/input-clipboard

pass the request body to the clipboard reader.

On some systems, particularly wayland on linux, the window needs to be focused in order to read the clipboard, this is now a way to circumvent that.

The leaderboard mods said they're ok with these 3 routes, and there shouldn't be any issues with them.

## misc

Added Integration tests

Added enforcing correct method for routes, technically this is a breaking change, but it's more of a bugfix, existing queries were allowing any http method, even no method in the case of tests, but now they only allow GET, this realistically shouldn't break any program using it unless they had a similar bug.